### PR TITLE
Use SignalK admin UI Vite manifest for stylesheet discovery

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,19 +8,40 @@
 
   <!-- Dynamically inject the SignalK admin UI stylesheet.
        The filename is hashed by Vite and changes on every SignalK rebuild,
-       so we discover it at runtime by parsing the admin UI root page. -->
+       so we read the Vite manifest the admin UI publishes (server >= 2.27.0)
+       and fall back to parsing the admin UI root page on older servers. -->
   <script>
     (async () => {
+      const appendStylesheet = (href) => {
+        const el = document.createElement('link');
+        el.rel  = 'stylesheet';
+        el.href = href;
+        document.head.appendChild(el);
+      };
+      try {
+        const res = await fetch('/admin/.vite/manifest.json');
+        if (res.ok) {
+          const manifest = await res.json();
+          let found = false;
+          for (const entry of Object.values(manifest)) {
+            if (!entry.isEntry) continue;
+            for (const css of entry.css ?? []) {
+              appendStylesheet('/admin/' + css);
+              found = true;
+            }
+          }
+          if (found) return;
+        }
+      } catch (e) {
+        // fall through to legacy scrape
+      }
       try {
         const res  = await fetch('/');
         const html = await res.text();
         const doc  = new DOMParser().parseFromString(html, 'text/html');
         const link = doc.querySelector('link[rel="stylesheet"]');
         if (link) {
-          const el = document.createElement('link');
-          el.rel  = 'stylesheet';
-          el.href = new URL(link.getAttribute('href'), res.url).href;
-          document.head.appendChild(el);
+          appendStylesheet(new URL(link.getAttribute('href'), res.url).href);
         }
       } catch (e) {
         console.warn('[advancedwind] Could not load SignalK admin stylesheet:', e);


### PR DESCRIPTION
## Summary

Replaces the HTML-scrape approach for discovering the SignalK admin UI's hashed stylesheet with the Vite manifest that the server now publishes.

Since SignalK server **2.27.0** (PR [SignalK/signalk-server#2672](https://github.com/SignalK/signalk-server/pull/2672)), the admin UI exposes its Vite manifest at:

```
GET /admin/.vite/manifest.json
```

That manifest lists the current hashed asset names, including the admin stylesheet. Reading it as JSON is more robust than parsing the admin UI root page, which was fragile and would break if the markup structure changed.

The legacy HTML-scrape path is kept as a fallback so the webapp still works against servers older than 2.27.0.

Documented upstream in [docs/develop/webapps.md — "Inheriting the Admin UI's Styling"](https://github.com/SignalK/signalk-server/blob/master/docs/develop/webapps.md#inheriting-the-admin-uis-styling).

## Test plan

- [ ] Load the Insight webapp against a SignalK server >= 2.27.0 — confirm admin stylesheet loads via `/admin/.vite/manifest.json`
- [ ] Load against an older server — confirm fallback to root-page scrape still works