### PR TITLE
Fix #18 Cannot see apparent wind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 node_modules/.package-lock.json
 .package-lock.json
 public/TODO.md
+/.idea/

--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ module.exports = function (app) {
   let windShiftFast = null;  // SmoothedAngle on environment.wind.directionTrue (fast EMA)
   let windShiftSlow = null;  // SmoothedAngle on environment.wind.directionTrue (slow EMA / reference)
   let windShift = null;  // inline delta: angle diff (rad) between fast and slow means
-
+  let applyOptionChanges = null;  // Assigned in plugin.start so /settings can drain changedOptions immediately.
 
   plugin.registerWithRouter = function (router) {
     app.debug('registerWithRouter');
@@ -292,6 +292,12 @@ module.exports = function (app) {
       const incoming = req.body || {};
       for (const key of Object.keys(incoming)) {
         changedOptions[key] = clamped[key];
+      }
+      // Apply queued changes now. If we wait for calculate() to drain them, an
+      // apparent-wind source change can never take effect.
+      if (isRunning && typeof applyOptionChanges === 'function' && Object.keys(changedOptions).length) {
+        try { applyOptionChanges(); }
+        catch (e) { app.debug(`applyOptionChanges (PUT /settings) failed: ${e.message}`); }
       }
       // Return the full merged config (with bounds) so the client can update itself.
       res.json({ ...options, ...changedOptions, _bounds: paramBounds });
@@ -838,7 +844,7 @@ module.exports = function (app) {
 
     }
 
-    function applyOptionChanges() {
+    applyOptionChanges = function () {
       let needsSmootherReset = false;
       let needsWindShiftReset = false;
       // Pop each key-value pair from changedOptions
@@ -942,7 +948,7 @@ module.exports = function (app) {
       }
 
       saveOptions();
-    }
+    };
   }
 
 
@@ -977,6 +983,7 @@ module.exports = function (app) {
         windShiftFast = windShiftFast?.terminate();
         windShiftSlow = windShiftSlow?.terminate();
         windShift = windShift?.terminate();
+        applyOptionChanges = null;
         app.debug("plugin stopped");
         app.setPluginStatus("Stopped");
         resolve();

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "advancedwind",
-  "version": "2.6.0",
+  "version": "2.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
-    "../signalKutilities": {
-      "name": "signalkutilities",
-      "version": "1.9.1",
+    "node_modules/signalkutilities": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/signalkutilities/-/signalkutilities-1.12.1.tgz",
+      "integrity": "sha512-KkudoYJbKHZOImyoswWzcG6hK3RzDKVNhk2idvZemlpw134bhsIBpYSb/lRvK+F0y0JGeLUA9bmi3cpoW2Sk6A==",
       "license": "ISC",
       "engines": {
         "node": ">=18"

--- a/tests/stale-source-deadlock.test.js
+++ b/tests/stale-source-deadlock.test.js
@@ -1,0 +1,216 @@
+// Regression test for the "stale apparent-wind source filter" deadlock.
+//
+// Scenario:
+//   - A user had an older wind instrument; its source label ("n2k.OLD") was
+//     saved into the plugin config as windSpeedSource.
+//   - The instrument was replaced; the new one publishes apparent wind under
+//     source "n2k.1".
+//   - The user opens the plugin webapp and tries to fix the source via the
+//     dropdown.
+//
+// Bug (pre-fix):
+//   - The apparent-wind input handler's label filter rejects every n2k.1
+//     delta because the stale label ("n2k.OLD") doesn't match. The path-match
+//     branch still records "n2k.1" in the sources set, so the dropdown shows
+//     it as an option, but no value is captured. polar.ready stays false,
+//     the smoother never samples, apparentWind.onChange never fires, and
+//     calculate() — the only drainer of `changedOptions` — never runs.
+//   - Therefore picking "n2k.1" in the UI updates the in-memory `options`
+//     mirror but never reaches the handler. The form looks right, the data
+//     never appears, and the user is stuck.
+//
+// Fix:
+//   - PUT /settings drains changedOptions immediately by calling
+//     applyOptionChanges() instead of waiting for the next calculate()
+//     cycle.
+//
+// What this test checks:
+//   1. With a stale `windSpeedSource`, n2k.1 deltas are observed (source
+//      shows up in the dropdown) but the smoother stays at 0 samples.
+//   2. PUT /settings to the correct source causes the next n2k.1 delta to
+//      flow end-to-end (smoother samples, state.ready=true, magnitude > 0).
+//
+// Without the fix, step 2 fails: nSamples stays 0 and ready stays false.
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path  = require('node:path');
+
+// ---------------------------------------------------------------------------
+// Minimal SK app mock — only the surface the plugin & signalkutilities use.
+// ---------------------------------------------------------------------------
+function makeApp(initialConfig) {
+  // Stored config is wrapped the way SK serves it from readPluginOptions().
+  let stored = { configuration: { ...initialConfig } };
+  const deltaHandlers = [];
+
+  return {
+    debug: () => {},
+    error: () => {},
+    setPluginStatus: () => {},
+    config: { port: 3000 },
+    selfContext: 'vessels.self',
+    readPluginOptions() { return stored; },
+    savePluginOptions(opts, cb) {
+      stored = { configuration: { ...opts } };
+      if (cb) cb(null);
+    },
+    // signalkutilities calls getSelfPath().meta — return undefined so the
+    // handler falls back to the REST cache (which we serve via fetch below).
+    getSelfPath() { return undefined; },
+    registerDeltaInputHandler(fn) { deltaHandlers.push(fn); },
+    // Apparent wind subscribes with passOn=false (preventDuplication=true),
+    // so it never hits subscriptionmanager. Other inputs do, but we don't
+    // care about them for this test.
+    subscriptionmanager: { subscribe() {} },
+    // The plugin's own back-calc output goes through handleMessage. Route it
+    // back into the delta chain so the isOwnSource check is exercised
+    // realistically (it should filter the plugin's deltas out).
+    handleMessage(_pluginId, msg) { this._deliver(msg); },
+
+    // Test-only helper: push a delta through the registered handler chain.
+    _deliver(delta) {
+      let i = 0;
+      const next = (d) => {
+        if (i >= deltaHandlers.length) return;
+        const h = deltaHandlers[i++];
+        h(d, next);
+      };
+      next(delta);
+    },
+  };
+}
+
+// Minimal Express-like router mock.
+function makeRouter() {
+  const routes = { get: {}, put: {} };
+  return {
+    get(p, h) { routes.get[p] = h; },
+    put(p, h) { routes.put[p] = h; },
+    routes,
+  };
+}
+
+// /report response helper.
+function getReport(router) {
+  let body;
+  router.routes.get['/report'](
+    {},
+    { status() { return this; }, json(j) { body = j; } }
+  );
+  return body;
+}
+
+// PUT /settings helper.
+function putSettings(router, partial) {
+  let body;
+  router.routes.put['/settings'](
+    { body: partial },
+    { status() { return this; }, json(j) { body = j; } }
+  );
+  return body;
+}
+
+// REST /meta is fire-and-forget — always succeed so pathKnown becomes true
+// quickly (doesn't change the test outcome, but keeps the warnings clean).
+global.fetch = async () => ({
+  ok: true,
+  json: async () => ({ units: 'm/s' }),
+});
+
+// Yield long enough for fire-and-forget promises (_fetchRestMeta) to settle.
+const tick = () => new Promise((r) => setImmediate(r));
+
+// Apparent-wind delta from the *current* instrument.
+const APPARENT_DELTA = {
+  context: 'vessels.self',
+  updates: [{
+    $source: 'n2k.1',
+    values: [
+      { path: 'environment.wind.speedApparent', value: 5.5 },
+      { path: 'environment.wind.angleApparent', value: -0.69 },
+    ],
+  }],
+};
+
+const STALE_CONFIG = {
+  version: '3.3',
+  // The previous wind instrument's source — no longer publishing.
+  windSpeedSource: 'n2k.OLD',
+  preventDuplication: true,
+  backCalculateApparentWind: true,
+  calculateGroundWind: false,
+  correctForMisalign: false,
+  correctForMastRotation: false,
+  correctForMastHeel: false,
+  correctForMastMovement: false,
+  correctForUpwash: false,
+  correctForLeeway: false,
+  correctForHeight: false,
+  stalenessDetection: true,
+};
+
+const pluginFactory = require(path.resolve(__dirname, '..', 'index.js'));
+
+test('stale windSpeedSource discovers n2k.1 source but blocks the value', async () => {
+  const app = makeApp(STALE_CONFIG);
+  const plugin = pluginFactory(app);
+  const router = makeRouter();
+  plugin.registerWithRouter(router);
+  await plugin.start();
+
+  // Send a real delta from the actual current source.
+  app._deliver(APPARENT_DELTA);
+  await tick();
+
+  const report = getReport(router);
+  const aw = report.polars['apparentWind.smoothed'];
+
+  assert.equal(aw.state.ready, false,
+    'apparent wind should not be ready — filter rejects the unknown source');
+  assert.equal(aw.state.hasDelta, false,
+    'smoother should not have sampled yet');
+  assert.equal(aw.state.nSamples, 0, 'no samples taken');
+  assert.deepEqual(aw.state.sources, ['n2k.1'],
+    'source name is still discovered (this is what populates the dropdown)');
+
+  await plugin.stop();
+});
+
+test('picking the correct source via PUT /settings unblocks apparent wind',
+async () => {
+  const app = makeApp(STALE_CONFIG);
+  const plugin = pluginFactory(app);
+  const router = makeRouter();
+  plugin.registerWithRouter(router);
+  await plugin.start();
+
+  // First delta: rejected by the stale filter.
+  app._deliver(APPARENT_DELTA);
+  await tick();
+  assert.equal(getReport(router).polars['apparentWind.smoothed'].state.ready,
+    false, 'precondition: stuck before reconfiguration');
+
+  // User picks "n2k.1" in the dropdown. With the fix this drains
+  // changedOptions immediately via applyOptionChanges(). Without the fix
+  // it just sits in changedOptions waiting for a calculate() that will
+  // never happen.
+  putSettings(router, { windSpeedSource: 'n2k.1' });
+
+  // Next delta arrives.
+  app._deliver(APPARENT_DELTA);
+  await tick();
+
+  const aw = getReport(router).polars['apparentWind.smoothed'];
+
+  assert.equal(aw.state.ready, true,
+    'apparent wind should be ready once the new source filter is active');
+  assert.ok(aw.state.nSamples > 0,
+    'smoother should have sampled at least once');
+  assert.ok(aw.magnitude > 0,
+    'magnitude should reflect the n2k.1 wind value (~5.5 m/s)');
+
+  await plugin.stop();
+});


### PR DESCRIPTION
Fix #18 by ensuring that an old unknown source does not block setting an new one.

I have not been able to verify this on my boat, but the AI generated fix does appear plausible.
I don't really like the assigning of a function rather than perhaps just having a boolean... but by javascript-foo is low???
Maybe it at least needs another `typeof applyOptionChanges === 'function'` check at the other call site?

Will test on boat when it stops raining.